### PR TITLE
(feat): add directory listing, refactor config api

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,8 @@ var webserver = require('gulp-webserver');
 gulp.task('webserver', function() {
   gulp.src('app')
     .pipe(webserver({
-      livereload: true
+      livereload: true,
+      directoryListing: true
     }));
 });
 ```
@@ -33,7 +34,8 @@ Key | Type | Default | Description |
 --- | --- | --- | --- |
 `host` | String | `localhost` | hostname of the webserver
 `port` | Number | `8000` | port of the webserver
-`livereload` | Boolean/Number | `false` | whether to use livereload (custom port also possible as value, default is `35729`)
+`livereload` | Boolean/Object | `false` | whether to use livereload. For advanced options, provide an object. You can use the 'port' property to set a custom live reload port.
+`directoryListing` | Boolean/Object | `false` | whether to display a directory listing. For advanced options, provide an object. You can use the 'path' property to set a custom path or the 'options' property to set custom [serve-index](https://github.com/expressjs/serve-index) options.
 `fallback` | String | `undefined` | file to fall back to (relative to webserver root)
 `https` | Boolean | `false` | *feature coming soon*
 `middleware` | Array | `[]` | *feature coming soon*

--- a/package.json
+++ b/package.json
@@ -31,6 +31,8 @@
     "connect-livereload": "^0.4.0",
     "gulp-util": "^2.2.19",
     "node-watch": "^0.3.4",
+    "node.extend": "^1.0.10",
+    "serve-index": "^1.1.4",
     "serve-static": "^1.3.0",
     "through2": "^0.5.1",
     "tiny-lr": "0.0.9"

--- a/src/enableMiddlewareShorthand/index.js
+++ b/src/enableMiddlewareShorthand/index.js
@@ -1,0 +1,26 @@
+var extend = require('node.extend');
+
+// TODO: Make this its own npm module and repo
+module.exports = function(defaults, options, props)
+{
+  var originalDefaults = extend({},defaults);
+  var config = extend(defaults, options);
+
+  // If we get a single string, convert it to a single item array
+  if(Object.prototype.toString.call(props) == '[object String]') {
+    props = [props];
+  }
+
+  // Loop through all of the given middlewares
+  for (var i = 0, len = props.length; i < len; i++) {
+    var prop = props[i];
+    // If using the shorthand syntax
+    if (config[prop] === true) {
+      // Replace the given tree for the tree defaults
+      config[prop] = extend(true, {}, originalDefaults[prop]);
+      // Set the enable flag, which then can be reliably used for conditionals
+      config[prop].enable = true;
+    }
+  }
+  return config;
+};

--- a/src/index.js
+++ b/src/index.js
@@ -7,42 +7,88 @@ var connectLivereload = require('connect-livereload');
 var tinyLr = require('tiny-lr');
 var watch = require('node-watch');
 var fs = require('fs');
+var serveIndex = require('serve-index');
+var path = require('path');
+var enableMiddlewareShorthand = require('./enableMiddlewareShorthand');
 
 module.exports = function(options) {
+  
+  var defaults = {
 
-  options = options || {};
+    /**
+     *
+     * BASIC DEFAULTS
+     *
+     **/
 
-  var host = options.host || 'localhost';
-  var port = options.port || 8000;
-  var livereloadPort = options.livereload || false;
+    host: 'localhost',
+    port: 8000,
+    fallback: false,
 
-  if (livereloadPort === true) {
-    livereloadPort = 35729;
-  }
+    /**
+     *
+     * MIDDLEWARE DEFAULTS
+     *
+     * NOTE:
+     *  All middleware should defaults should have the 'enable'
+     *  property if you want to support shorthand syntax like:
+     *
+     *    webserver({
+     *      livereload: true
+     *    });
+     *
+     */
 
-  var fallback = options.fallback;
+    // Middleware: Livereload
+    livereload: {
+      enable:false,
+      port: 35729
+    },
+
+    // Middleware: Directory listing
+    // For possible options, see: 
+    //  https://github.com/expressjs/serve-index
+    directoryListing: {
+      enable: false,
+      path: './',
+      options: undefined
+    }
+
+  };
+
+  // Deep extend user provided options over the all of the defaults
+  // Allow shorthand syntax, using the enable property as a flag
+  var config = enableMiddlewareShorthand(defaults, options, ['directoryListing','livereload']);
 
   var app = connect();
+
   var lrServer;
 
-  if (livereloadPort) {
+  if (config.livereload.enable) {
 
     app.use(connectLivereload({
-      port: livereloadPort
+      port: config.livereload.port
     }));
 
     lrServer = tinyLr();
-    lrServer.listen(livereloadPort);
+    lrServer.listen(config.livereload.port);
 
   }
 
+  if (config.directoryListing.enable) {
+
+      app.use(serveIndex(path.resolve(config.directoryListing.path), config.directoryListing.options));
+
+  }
+
+  // Create server
   var stream = through.obj(function(file, enc, callback) {
 
     app.use(serveStatic(file.path));
 
-    if (fallback) {
+    if (config.fallback) {
 
-      var fallbackFile = file.path + '/' + fallback;
+      var fallbackFile = file.path + '/' + config.fallback;
 
       if (fs.existsSync(fallbackFile)) {
 
@@ -53,7 +99,7 @@ module.exports = function(options) {
       }
     }
 
-    if (livereloadPort) {
+    if (config.livereload.enable) {
 
       watch(file.path, function(filename) {
 
@@ -73,15 +119,15 @@ module.exports = function(options) {
 
   });
 
-  var webserver = http.createServer(app).listen(port, host);
+  var webserver = http.createServer(app).listen(config.port, config.host);
 
-  gutil.log('Webserver started at', gutil.colors.cyan('http://' + host + ':' + port));
+  gutil.log('Webserver started at', gutil.colors.cyan('http://' + config.host + ':' + config.port));
 
   stream.on('kill', function() {
 
     webserver.close();
 
-    if (livereloadPort) {
+    if (config.livereload.enable) {
       lrServer.close();
     }
 

--- a/test/fixtures/directoryIndexMissing/file.html
+++ b/test/fixtures/directoryIndexMissing/file.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<title></title>
+</head>
+<body>
+  A file in a directory with no index.html
+</body>
+</html>

--- a/test/index.js
+++ b/test/index.js
@@ -10,6 +10,10 @@ describe('gulp-webserver', function() {
     path: __dirname + '/fixtures'
   });
 
+  var directoryIndexMissingDir = new File({
+    path: __dirname + '/fixtures/directoryIndexMissing'
+  });
+
   afterEach(function() {
     stream.emit('kill');
   });
@@ -82,6 +86,95 @@ describe('gulp-webserver', function() {
         done(err);
       });
 
+  });
+
+  it('should show a directory listing when the shorthand setting is enabled', function(done) {
+
+    stream = webserver({
+      directoryListing: true
+    });
+
+    stream.write(directoryIndexMissingDir);
+
+    request('http://localhost:8000')
+      .get('/')
+      .expect(200,/listing directory/)
+      .end(function(err) {
+        if (err) return done(err);
+        done(err);
+      });
+
+  });
+
+  it('should not show a directory listing when the shorthand setting is disabled', function(done) {
+
+    stream = webserver({
+      directoryListing: false
+    });
+
+    stream.write(directoryIndexMissingDir);
+
+    request('http://localhost:8000')
+      .get('/')
+      .expect(404,/Cannot GET/)
+      .end(function(err) {
+        if (err) return done(err);
+        done(err);
+      });
+
+  });
+
+  it('should start the livereload server when the shorthand setting is enabled', function(done) {
+
+    stream = webserver({
+      livereload: true
+    });
+
+    stream.write(rootDir);
+
+    request('http://localhost:8000')
+      .get('/')
+      .expect(200,/Hello World/)
+      .end(function(err) {
+        if (err) return done(err);
+      });
+    request('http://localhost:35729')
+      .get('/')
+      .expect(200,/tinylr/)
+      .end(function(err) {
+        if (err) return done(err);
+        done(err);
+      });
+  });
+
+  it('should not start the livereload server when the shorthand setting is disabled', function(done) {
+
+    stream = webserver({
+      livereload: false
+    });
+
+    stream.write(rootDir);
+
+    request('http://localhost:8000')
+      .get('/')
+      .expect(200,/Hello World/)
+      .end(function(err) {
+        if (err) return done(err);
+      });
+    request('http://localhost:35729')
+      .get('/')
+      .end(function(err) {
+        if(err && err.code === "ECONNREFUSED") {
+          done();
+        } else {
+          if (err) {
+            return done(err);
+          } else {
+            done(new Error('livereload should not be started when shorthand middleware setting is set to false'));
+          }
+        }
+        
+      });
   });
 
 });


### PR DESCRIPTION
In order to have a more consistent config api I removed the ability to pass
livereload as a number, but added the ability to check if it is an object.
You can still use the true/false shorthand for the livereload middleware.
Added the ability to enable, disable, configure the serve-index directory
listing middleware. Added some basic tests for shorthand enable/disable
syntax for livereload and directoryListing middleware.

Since I removed the livereload property as a number from the config, that
is a breaking change. This commit fixes #3.
