### PR TITLE
Make it possible to specify which path to open

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Key | Type | Default | Description |
 `livereload` | Boolean/Object | `false` | whether to use livereload. For advanced options, provide an object. You can use the 'port' property to set a custom live reload port.
 `directoryListing` | Boolean/Object | `false` | whether to display a directory listing. For advanced options, provide an object. You can use the 'path' property to set a custom path or the 'options' property to set custom [serve-index](https://github.com/expressjs/serve-index) options.
 `fallback` | String | `undefined` | file to fall back to (relative to webserver root)
-`open` | Boolean/Object | `false` | open the localhost server in the browser
+`open` | Boolean/String | `false` | open the localhost server in the browser. By providing a String you can specify the path to open.
 `https` | Boolean/Object | `false` | whether to use https or not. By default, `gulp-webserver` provides you with a development certificate but you remain free to specify a path for your key and certificate by providing an object like this one: `{key: 'path/to/key.pem', cert: 'path/to/cert.pem'}`.
 `middleware` | Array | `[]` | *feature coming soon*
 `proxies` | Array | `[]`| a list of proxy objects.  Each proxy object can be specified by `{source: '/abc', target: 'http://localhost:8080/abc'}`.

--- a/src/index.js
+++ b/src/index.js
@@ -74,11 +74,16 @@ module.exports = function(options) {
     'livereload'
   ]);
 
+  if (typeof config.open === 'string' && config.open.length > 0) {
+    // ensure leading slash
+    config.open = (config.open.indexOf('/') !== 0 ? '/' : '') + config.open;
+  }
+
   var app = connect();
 
   var openInBrowser = function() {
     if (config.open === false) return;
-    open('http' + (config.https ? 's' : '') + '://' + config.host + ':' + config.port);
+    open('http' + (config.https ? 's' : '') + '://' + config.host + ':' + config.port + (typeof config.open === 'string' ? config.open : ''));
   };
 
   var lrServer;


### PR DESCRIPTION
This makes it possible to provide a string for the open configuration parameter. When a string is given this will be used as the path to open.

I didn't write tests for this yet, because i don't know how to mock (or spy on) the open package.
