### PR TITLE
[WIP] Add test coverage scanner and CONTRIBUTING doc

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,4 +16,4 @@ test coverage as files change.
    they add or change current functionality.
 5. Commit your changes (`git commit -am 'Added some new feature`)
 6. Push to the branch (`git push origin my-new-feature`)
-7. Create a pull request
+7. Create a [pull request](https://help.github.com/articles/using-pull-requests)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,19 @@
+# Contributing
+
+## Developing
+
+A [`gulpfile`](gulpfile.js) has been setup to help with developing new features in
+`gulp-webserver`. You can start `develop` task with `npm run-script develop`,
+which will watch the code for changes and both run the test suite and show the
+test coverage as files change.
+
+## Contributing
+
+1. Fork it
+2. Create your feature branch (`git checkout -b my-new-feature`)
+3. Test your changes to the best of your ability (`gulp spec`)
+4. Update the documentation in [README.md](README.md) to reflect your changes if
+   they add or change current functionality.
+5. Commit your changes (`git commit -am 'Added some new feature`)
+6. Push to the branch (`git push origin my-new-feature`)
+7. Create a pull request

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,0 +1,21 @@
+var gulp = require('gulp'),
+    mocha = require('gulp-mocha'),
+    istanbul = require('gulp-istanbul');
+
+gulp.task('spec', function (cb) {
+  gulp.src('src/**/*.js')
+      .pipe(istanbul())
+      .on('finish', function () {
+        gulp.src('test/index.js')
+            .pipe(mocha({ bail: false }))
+            .on('error', function () {})
+            .pipe(istanbul.writeReports())
+            .on('end', cb);
+      });
+});
+
+gulp.task('develop', function () {
+  gulp.watch(['src/**/*.js', 'test/index.js'], ['spec']);
+});
+
+gulp.task('default', ['spec']);

--- a/package.json
+++ b/package.json
@@ -22,7 +22,14 @@
     "url": "https://github.com/schickling/gulp-webserver/issues"
   },
   "homepage": "https://github.com/schickling/gulp-webserver",
+  "scripts": {
+    "test": "gulp spec",
+    "develop": "gulp develop"
+  },
   "devDependencies": {
+    "gulp": "^3.8.8",
+    "gulp-istanbul": "^0.3.0",
+    "gulp-mocha": "^1.1.0",
     "mocha": "^1.20.1",
     "supertest": "^0.13.0"
   },

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "src/index.js",
   "scripts": {
     "test": "mocha"
+    "develop": "gulp develop"
   },
   "repository": {
     "type": "git",
@@ -22,10 +23,6 @@
     "url": "https://github.com/schickling/gulp-webserver/issues"
   },
   "homepage": "https://github.com/schickling/gulp-webserver",
-  "scripts": {
-    "test": "gulp spec",
-    "develop": "gulp develop"
-  },
   "devDependencies": {
     "gulp": "^3.8.8",
     "gulp-istanbul": "^0.3.0",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Gulp plugin to run a local webserver with LiveReload",
   "main": "src/index.js",
   "scripts": {
-    "test": "mocha"
+    "test": "mocha",
     "develop": "gulp develop"
   },
   "repository": {

--- a/test/index.js
+++ b/test/index.js
@@ -278,6 +278,7 @@ describe('gulp-webserver', function() {
       .end(function(err) {
         if (err) return done(err);
         done(err);
+        proxyStream.emit('kill');
       });
 
   });


### PR DESCRIPTION
I though it would be good to help new developers contribute back to `gulp-webserver` by using gulp to run tests and setting up a watch task to be able to run tests as they change. While setting up the gulp suite, I also added Istanbul to check test coverage.

The other piece of the PR is adding a CONTRIBUTING document. This will help to guide developers in a direction of how they can contribute to `gulp-webserver` using the gulp suite and the proper procedure of using branches and pull requests.
