### PR TITLE
fix content-type not being set with fallback. Necessary for safari

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -142,6 +142,7 @@ module.exports = function(options) {
       if (fs.existsSync(fallbackFile)) {
 
         app.use(function(req, res) {
+          res.setHeader('Content-Type', 'text/html; charset=utf-8');
           fs.createReadStream(fallbackFile).pipe(res);
         });
 

--- a/test/index.js
+++ b/test/index.js
@@ -127,6 +127,7 @@ describe('gulp-webserver', function() {
     request('http://localhost:8000')
       .get('/some/random/path/')
       .expect(200, /Default/)
+      .expect('Content-Type', /text\/html; charset=utf-8/)
       .end(function(err) {
         if (err) return done(err);
         done(err);


### PR DESCRIPTION
Hi!

Thanks for your work! I ran into an issue while using safari with a fallback url. Turns out Safari auto-assumes `text/plain` for non-specified responses... This explicitly sets it to `text/html`.

Thanks!
