### PR TITLE
Support for proxy-middleware options

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Key | Type | Default | Description |
 `open` | Boolean/String | `false` | open the localhost server in the browser. By providing a String you can specify the path to open.
 `https` | Boolean/Object | `false` | whether to use https or not. By default, `gulp-webserver` provides you with a development certificate but you remain free to specify a path for your key and certificate by providing an object like this one: `{key: 'path/to/key.pem', cert: 'path/to/cert.pem'}`.
 `middleware` | Array | `[]` | *feature coming soon*
-`proxies` | Array | `[]`| a list of proxy objects.  Each proxy object can be specified by `{source: '/abc', target: 'http://localhost:8080/abc'}`.
+`proxies` | Array | `[]`| a list of proxy objects.  Each proxy object can be specified by `{source: '/abc', target: 'http://localhost:8080/abc', options: {headers: {'ABC_HEADER': 'abc'}}}`.
 
 ## FAQ
 

--- a/src/index.js
+++ b/src/index.js
@@ -13,7 +13,9 @@ var serveIndex = require('serve-index');
 var path = require('path');
 var open = require('open');
 var url = require('url');
+var extend = require('node.extend');
 var enableMiddlewareShorthand = require('./enableMiddlewareShorthand');
+
 
 module.exports = function(options) {
 
@@ -126,7 +128,11 @@ module.exports = function(options) {
 
   // Proxy requests
   for (var i = 0, len = config.proxies.length; i < len; i++) {
-    app.use(config.proxies[i].source, proxy(url.parse(config.proxies[i].target)));
+    var proxyoptions = url.parse(config.proxies[i].target);
+    if (config.proxies[i].hasOwnProperty('options')) {
+      extend(proxyoptions, config.proxies[i].options);
+    }
+    app.use(config.proxies[i].source, proxy(proxyoptions));
   }
 
 


### PR DESCRIPTION
In webserver's current implementation it isn't possible to configure proxy-middleware.
This pull request add support for an optional "options" argument on a proxy configuration.

Since webserver doesn't support middleware, I wasn't able to properly implement the test. Currently the test only proves that it doesn't break anything. 
Using another server I have verified that the proxy was properly configured.
