### PR TITLE
Mention `enable: true` when passing object to LR

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Key | Type | Default | Description |
 --- | --- | --- | --- |
 `host` | String | `localhost` | hostname of the webserver
 `port` | Number | `8000` | port of the webserver
-`livereload` | Boolean/Object | `false` | whether to use livereload. For advanced options, provide an object. You can use the 'port' property to set a custom live reload port and the `filter` function to filter out files to watch.
+`livereload` | Boolean/Object | `false` | whether to use livereload. For advanced options, provide an object. You can use the 'port' property to set a custom live reload port and the `filter` function to filter out files to watch. The object also needs to set `enable` property to true (e.g. `enable: true`) in order to activate the livereload mode. It is off by default.
 `directoryListing` | Boolean/Object | `false` | whether to display a directory listing. For advanced options, provide an object with the 'enable' property set to true. You can use the 'path' property to set a custom path or the 'options' property to set custom [serve-index](https://github.com/expressjs/serve-index) options.
 `fallback` | String | `undefined` | file to fall back to (relative to webserver root)
 `open` | Boolean/String | `false` | open the localhost server in the browser. By providing a String you can specify the path to open (for complete path, use the complete url `http://my-server:8080/public/`) .
@@ -58,6 +58,28 @@ gulp.task('webserver', function() {
   gulp.src('app')
     .pipe(webserver({
       fallback: 'index.html'
+    }));
+});
+```
+
+#### How can I pass a custom filter to livereload?
+
+**Solution**: Set `enable: true` and provide filter function in `filter:` property of the livereload object. For example:
+
+```js
+gulp.task('webserver', function() {
+  gulp.src('app')
+    .pipe(webserver({
+      livereload: {
+        enable: true, // need this set to true to enable livereload
+        filter: function(fileName) {
+          if (fileName.match(/.map$/)) { // exclude all source maps from livereload
+            return false;
+          } else {
+            return true;
+          }
+        }
+      }
     }));
 });
 ```


### PR DESCRIPTION
I've realized that setting `filter` property in livereload object is not enough to activate the livereload. The object also needs to set `enable: true` for LR to kick in. Updating readme and adding one more FAQ to make it clear.
