### PR TITLE
can we make the auto reload more responsive?

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -164,7 +164,8 @@ module.exports = function(options) {
     if (config.livereload.enable) {
       var watchOptions = {
         ignoreDotFiles: true,
-        filter: config.livereload.filter
+        filter: config.livereload.filter,
+        interval: 500
       };
       watch.watchTree(file.path, watchOptions, function (filename) {
         lrServer.changed({


### PR DESCRIPTION
the default interval for the file watcher is 5007, that means even if gulp detects my changes to the original file and regenerated it within several milliseconds, i need to wait for at least 5 seconds for the page to refresh (because it take 5 sec for gulp-webserver to discover that)

it would be awesome if my page get refreshed as soon as i hit ⌘+S, so i override the default interval parameter to be 500ms (on my machine it often takes 2-3ms to generate a file, and it think 500ms for discovering such a change is pretty enough.)
