### PR TITLE
Upgrade the connect-livereload dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "connect": "^3.0.1",
-    "connect-livereload": "^0.4.0",
+    "connect-livereload": "^0.5.0",
     "gulp-util": "^2.2.19",
     "isarray": "0.0.1",
     "node.extend": "^1.0.10",


### PR DESCRIPTION
The current version of `connect-livereload` is `0.5.3`. This module uses `^0.4.0` as dependency.

This upgrade would solve some problems where `connect-livereload` generates malformed html markup. Tests still run successfully.
