### PR TITLE
Unwatch livereload files on kill

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -223,6 +223,10 @@ module.exports = function(options) {
 
     if (config.livereload.enable) {
       lrServer.close();
+
+      files.forEach(function (file) {
+        watch.unwatchTree(file.path);
+      });
     }
 
   });


### PR DESCRIPTION
Currently, emitting 'kill' on the stream does not complete the gulp task completely, if livereload is enabled as described in #95. This PR fixes this issue, by unwatching the watched files on 'kill'.