### PR TITLE
Pass entire livereload object

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -104,9 +104,7 @@ module.exports = function(options) {
 
   if (config.livereload.enable) {
 
-    app.use(connectLivereload({
-      port: config.livereload.port
-    }));
+    app.use(connectLivereload(config.livereload));
 
     if (config.https) {
       if (config.https.pfx) {


### PR DESCRIPTION
Sometimes you want to put the webserver behind a proxy, like for consistent https/domain support. Ideally, we'd have appropriate control over the livereload configuration, so we can set the src property.